### PR TITLE
検索フロントモック作成

### DIFF
--- a/client/components/molecules/SearchInput.tsx
+++ b/client/components/molecules/SearchInput.tsx
@@ -1,0 +1,32 @@
+import React, { useContext } from 'react';
+import { Button, Input, Icon } from 'semantic-ui-react';
+import styled from 'styled-components';
+
+import { LoadingContext } from '../../Router';
+
+const SearchInput = () => {
+  const { setLoading } = useContext(LoadingContext);
+  const onClickSearch = () => {
+    setLoading(true);
+    setTimeout(() => setLoading(false), 3000);
+  };
+
+  return (
+    <SCsearchContainer>
+      <SCsearchInput placeholder="投稿を検索する" />
+      <Button icon color="teal" onClick={onClickSearch}>
+        <Icon name="search" />
+      </Button>
+    </SCsearchContainer>
+  );
+};
+
+export default SearchInput;
+
+const SCsearchContainer = styled.div`
+  display: flex;
+`;
+
+const SCsearchInput = styled(Input)`
+  width: 100%;
+`;

--- a/client/components/molecules/SearchInput.tsx
+++ b/client/components/molecules/SearchInput.tsx
@@ -21,8 +21,6 @@ const SearchInput = () => {
   );
 };
 
-export default SearchInput;
-
 const SCsearchContainer = styled.div`
   display: flex;
 `;
@@ -30,3 +28,5 @@ const SCsearchContainer = styled.div`
 const SCsearchInput = styled(Input)`
   width: 100%;
 `;
+
+export default SearchInput;

--- a/client/components/pages/Home.tsx
+++ b/client/components/pages/Home.tsx
@@ -3,6 +3,7 @@ import { Button, Container, Segment, Tab, Icon } from 'semantic-ui-react';
 import styled from 'styled-components';
 import { useHistory } from 'react-router-dom';
 
+import SearchInput from '../molecules/SearchInput';
 import TabPopular from '../templates/TabPopular';
 import TabNew from '../templates/TabNew';
 
@@ -44,6 +45,7 @@ const Home = () => {
           <Button.Content hidden>(ｏﾟДﾟ)＝◯)`3゜)∵</Button.Content>
         </Button>
         <Segment raised textAlign="center">
+          <SearchInput />
           <SCmenuContainer>
             <Tab menu={{ pointing: true, secondary: true, color: 'teal' }} panes={panes} />
           </SCmenuContainer>


### PR DESCRIPTION
## 対応内容
![ダウンロード](https://s27.aconvert.com/convert/p3r68-cdx67/bs5cc-fcsh0.gif)


- 投稿検索をするための検索フォームを用意しました。
- 検索ボタンを押すとローディングするようになり、3秒後(ここで検索リクエストを送る、ダミーで3秒用意しています。)に元に戻ります。

## この時点でまだ対応していないこと
- 実際に検索できるところまではまだ対応してません。フォームの見た目の用意だけ対応しました。

## 特に見て欲しいところ
- 検索フォームについての記述(概念的にmoleculesで合ってますかね？)

よろしくお願いします。