### PR TITLE
戻る機能実装

### DIFF
--- a/client/components/atoms/BackButton.tsx
+++ b/client/components/atoms/BackButton.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Icon } from 'semantic-ui-react';
+import { useHistory } from 'react-router-dom';
+import styled from 'styled-components';
+
+import { COLOR_THEME } from '../../const';
+
+const BackButton = () => {
+  const history = useHistory();
+
+  const onClickBack = () => history.goBack();
+
+  return (
+    <SClinkText onClick={onClickBack}>
+      <Icon fitted name="arrow left" />
+      戻る
+    </SClinkText>
+  );
+};
+
+const SClinkText = styled.span`
+  text-decoration: underline;
+  cursor: pointer;
+  color: #666;
+  &:hover {
+    color: ${COLOR_THEME};
+  }
+`;
+
+export default BackButton;

--- a/client/components/pages/Detail.tsx
+++ b/client/components/pages/Detail.tsx
@@ -24,6 +24,7 @@ import DetailService from '../../repository/detail';
 import favorite from '../../repository/favorite';
 import Persist from '../../persist';
 import { LoadingContext } from '../../Router';
+import BackButton from '../atoms/BackButton';
 
 const Detail = () => {
   const reactAlert = useAlert();
@@ -87,6 +88,7 @@ const Detail = () => {
 
   return (
     <SCcontainer>
+      <BackButton />
       <Segment raised textAlign="center">
         {data ? (
           <>

--- a/client/components/pages/Post.tsx
+++ b/client/components/pages/Post.tsx
@@ -7,6 +7,7 @@ import { useAlert, types } from 'react-alert';
 import { COLOR_THEME } from '../../const';
 import PostService from '../../repository/post';
 import { LoadingContext } from '../../Router';
+import BackButton from '../atoms/BackButton';
 
 const Post = () => {
   const history = useHistory();
@@ -44,6 +45,7 @@ const Post = () => {
 
   return (
     <SCcontainer>
+      <BackButton />
       <Segment raised textAlign="center">
         <Header as="h2" style={{ color: COLOR_THEME }}>
           ブラックストーリー投稿


### PR DESCRIPTION
## 対応内容
- 新規投稿画面、詳細画面から戻るためのリンクを配置

## 特に見て欲しいところ
- 白枠内に入れようと思ったけどスマホ表示でタイトル長いときに微妙な感じになるので外に出した
- どうせならこの戻るの右のスペースをうまく使っていきたい(天気の情報、アイコン?だすとか)

## ぼやき
- 毎度毎度パックマンでるのもうざいなw 投稿の時だけでも良いかも...

## キャプチャ
![2020-04-02 00 34 03](https://user-images.githubusercontent.com/44320334/78156396-b7b24580-7479-11ea-8863-bca7d427d954.gif)
