### PR TITLE
ヒドイイネ削除機能追加

### DIFF
--- a/src/app/Eloquent/Favorite.php
+++ b/src/app/Eloquent/Favorite.php
@@ -25,4 +25,9 @@ class Favorite extends Model
     {
         return Favorite::create($request);
     }
+
+    public function deleteFavorite(array $request)
+    {
+        Favorite::where('post_id', $request)->orderby('id', 'asc')->first()->delete();
+    }
 }

--- a/src/app/Http/Controllers/Api/FavoriteController.php
+++ b/src/app/Http/Controllers/Api/FavoriteController.php
@@ -86,8 +86,14 @@ class FavoriteController extends Controller
      * @param  int  $id
      * @return Response
      */
-    public function destroy($id)
+    public function destroy(Request $request, Favorite $favorite)
     {
-        //
+        $unFavorite = $favorite->deleteFavorite($request->all());
+
+        $data = [
+            'post' => $unFavorite,
+        ];
+
+        return response()->json($data, 200);
     }
 }

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -21,4 +21,5 @@ Route::group(['middleware' => ['api']], function () {
     Route::resource('post', 'Api\PostController');
     Route::resource('favorite', 'Api\FavoriteController');
     Route::resource('comment', 'Api\CommentController');
+    Route::delete('favorite', 'Api\FavoriteController@destroy');
 });


### PR DESCRIPTION
## 対応内容
- ヒドイイネの削除機能追加

## 特に見て欲しいところ
- API繋ぐときにフロントからdeleteでリクエスト送ると405エラーになるのでルーティングにdeleteでメソッド指定したら繋ぐことができたのでそれで対応してます！
もし他に方法あれば直すので教えてください！！！
