### PR TITLE
ヒドイイネ削除機能追加

### DIFF
--- a/client/components/pages/Detail.tsx
+++ b/client/components/pages/Detail.tsx
@@ -49,19 +49,34 @@ const Detail = () => {
 
   const onClickNonfavo = async () => {
     if (!id) return;
-    if (isPushNonfavo) return;
-    const res = await favorite.registFavorite(parseInt(id));
-    if (!res.error) {
-      Persist.set(id?.toString(), !isPushNonfavo);
-      const favoriteCount = data.favoriteCount + 1;
-      const newData = { ...data, favoriteCount };
-      setData(newData);
-      setIsPushNonfavo(true);
+    if (!isPushNonfavo) {
+      const res = await favorite.registFavorite(parseInt(id));
+      if (!res.error) {
+        Persist.set(id?.toString(), !isPushNonfavo);
+        const favoriteCount = data.favoriteCount + 1;
+        const newData = { ...data, favoriteCount };
+        setData(newData);
+        setIsPushNonfavo(true);
+      } else {
+        if (!res.errorMessages) return;
+        reactAlert.show(res.errorMessages[0], {
+          type: types.ERROR,
+        });
+      }
     } else {
-      if (!res.errorMessages) return;
-      reactAlert.show(res.errorMessages[0], {
-        type: types.ERROR,
-      });
+      const res = await favorite.removeFavorite(parseInt(id));
+      if (!res.error) {
+        Persist.remove(id?.toString());
+        const favoriteCount = data.favoriteCount - 1;
+        const newData = { ...data, favoriteCount };
+        setData(newData);
+        setIsPushNonfavo(false);
+      } else {
+        if (!res.errorMessages) return;
+        reactAlert.show(res.errorMessages[0], {
+          type: types.ERROR,
+        });
+      }
     }
   };
 

--- a/client/repository/favorite.ts
+++ b/client/repository/favorite.ts
@@ -21,4 +21,20 @@ export default {
       return genericError;
     }
   },
+  async removeFavorite(id: number): Promise<SuccessResult<any> | ErrorResult> {
+    const response = await axiosInstance.delete(`/favorite?post_id=${id}`).catch((e: AxiosError) => {
+      if (e.isAxiosError) {
+        return internalServerError;
+      }
+    });
+    if (response?.status === 200) {
+      return {
+        error: false,
+        data: response?.data,
+        errorMessages: null,
+      };
+    } else {
+      return genericError;
+    }
+  },
 };

--- a/src/app/Eloquent/Favorite.php
+++ b/src/app/Eloquent/Favorite.php
@@ -25,4 +25,10 @@ class Favorite extends Model
     {
         return Favorite::create($request);
     }
+
+    public function deleteFavorite(array $request)
+    {
+        Favorite::where('post_id', $request)->orderby('id', 'asc')->first()->delete();
+    }
+
 }

--- a/src/app/Http/Controllers/Api/FavoriteController.php
+++ b/src/app/Http/Controllers/Api/FavoriteController.php
@@ -25,4 +25,23 @@ class FavoriteController extends Controller
 
         return response()->json($data, 200);
     }
+
+    /**
+     * ヒドイイネをFavoriteテーブルにから削除
+     *
+     * @param  Request  $request
+     * @param  Favorite $favorite
+     * @return Response
+     */
+    public function destroy(Request $request, Favorite $favorite)
+     {
+        $unFavorite = $favorite->deleteFavorite($request->all());
+
+        $data = [
+            'post' => $unFavorite,
+        ];
+
+        return response()->json($data, 200);
+     }
+
 }

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -17,4 +17,5 @@ Route::group(['middleware' => ['api']], function() {
     Route::resource('/post', 'Api\PostController', ['except' => ['edit','create']]);
     Route::resource('/favorite', 'Api\FavoriteController', ['only' => ['store']]);
     Route::resource('/comment' , 'Api\CommentController', ['only' => ['store']]);
+    Route::delete('favorite', 'Api\FavoriteController@destroy');
 });


### PR DESCRIPTION
## 対応内容
- ヒドイイネ削除機能追加

## 特に見て欲しいところ
- API繋ぐときにフロントからdeleteでリクエスト送ると405エラーになるのでルーティングにdeleteでメソッド指定したら繋ぐことができたのでそれで対応してます！
もし他に方法あれば直すので教えてください！！！