### PR TITLE
検索APIの繋ぎこみ

### DIFF
--- a/client/Router.tsx
+++ b/client/Router.tsx
@@ -9,7 +9,7 @@ import LoadingWithDimmer from './components/molecules/LoadingWithDimmer';
 import Home from './components/pages/Home';
 import Detail from './components/pages/Detail';
 import Post from './components/pages/Post';
-import { Loading } from './types/context';
+import { Loading, SearchKeyword } from './types/context';
 
 const alertOptions = {
   position: positions.TOP_CENTER,
@@ -19,23 +19,27 @@ const alertOptions = {
 };
 
 export const LoadingContext = createContext<Loading>({ loading: false, setLoading: () => {} });
+export const SearchKeywordContext = createContext<SearchKeyword>({ keyword: '', setKeyword: () => {} });
 
 const Router = () => {
   const [loading, setLoading] = useState(false);
+  const [keyword, setKeyword] = useState('');
 
   return (
     <SCcontainer>
       <AlertProvider template={AlertTemplate} {...alertOptions}>
         <LoadingContext.Provider value={{ loading, setLoading }}>
-          <BrowserRouter>
-            <HeaderLogo />
-            <LoadingWithDimmer />
-            <Switch>
-              <Route path="/" exact children={<Home />} />
-              <Route path="/detail/:id" children={<Detail />} />
-              <Route path="/post" children={<Post />} />
-            </Switch>
-          </BrowserRouter>
+          <SearchKeywordContext.Provider value={{ keyword, setKeyword }}>
+            <BrowserRouter>
+              <HeaderLogo />
+              <LoadingWithDimmer />
+              <Switch>
+                <Route path="/" exact children={<Home />} />
+                <Route path="/detail/:id" children={<Detail />} />
+                <Route path="/post" children={<Post />} />
+              </Switch>
+            </BrowserRouter>
+          </SearchKeywordContext.Provider>
         </LoadingContext.Provider>
       </AlertProvider>
     </SCcontainer>

--- a/client/Router.tsx
+++ b/client/Router.tsx
@@ -9,7 +9,7 @@ import LoadingWithDimmer from './components/molecules/LoadingWithDimmer';
 import Home from './components/pages/Home';
 import Detail from './components/pages/Detail';
 import Post from './components/pages/Post';
-import { Loading, SearchKeyword } from './types/context';
+import { Loading } from './types/context';
 
 const alertOptions = {
   position: positions.TOP_CENTER,
@@ -19,27 +19,23 @@ const alertOptions = {
 };
 
 export const LoadingContext = createContext<Loading>({ loading: false, setLoading: () => {} });
-export const SearchKeywordContext = createContext<SearchKeyword>({ keyword: '', setKeyword: () => {} });
 
 const Router = () => {
   const [loading, setLoading] = useState(false);
-  const [keyword, setKeyword] = useState('');
 
   return (
     <SCcontainer>
       <AlertProvider template={AlertTemplate} {...alertOptions}>
         <LoadingContext.Provider value={{ loading, setLoading }}>
-          <SearchKeywordContext.Provider value={{ keyword, setKeyword }}>
-            <BrowserRouter>
-              <HeaderLogo />
-              <LoadingWithDimmer />
-              <Switch>
-                <Route path="/" exact children={<Home />} />
-                <Route path="/detail/:id" children={<Detail />} />
-                <Route path="/post" children={<Post />} />
-              </Switch>
-            </BrowserRouter>
-          </SearchKeywordContext.Provider>
+          <BrowserRouter>
+            <HeaderLogo />
+            <LoadingWithDimmer />
+            <Switch>
+              <Route path="/" exact children={<Home />} />
+              <Route path="/detail/:id" children={<Detail />} />
+              <Route path="/post" children={<Post />} />
+            </Switch>
+          </BrowserRouter>
         </LoadingContext.Provider>
       </AlertProvider>
     </SCcontainer>

--- a/client/components/molecules/SearchInput.tsx
+++ b/client/components/molecules/SearchInput.tsx
@@ -1,29 +1,20 @@
-import React, { useContext } from 'react';
-import { Button, Input, Icon } from 'semantic-ui-react';
+import React from 'react';
+import { Input } from 'semantic-ui-react';
 import styled from 'styled-components';
 
-import { SearchKeywordContext } from '../../Router';
-
 type Props = {
-  count: number;
-  orderBy: string;
-  onClickSearchButton: (count: number, orderBy: string, keyword: string) => void;
+  onChangeSetKeyword: (content: string) => void;
 };
 
 const SearchInput = (props: Props) => {
-  const { count, orderBy, onClickSearchButton } = props;
-  const { keyword, setKeyword } = useContext(SearchKeywordContext);
+  const { onChangeSetKeyword } = props;
 
   return (
     <SCsearchContainer>
       <SCsearchInput
         placeholder="投稿を検索する"
-        onChange={(_e: React.ChangeEvent<HTMLInputElement>, data: { value: string }) => setKeyword(data.value)}
-        defaultValue={keyword}
+        onChange={(_e: React.ChangeEvent<HTMLInputElement>, data: { value: string }) => onChangeSetKeyword(data.value)}
       />
-      <Button icon color="teal" onClick={() => onClickSearchButton(count, orderBy, keyword)}>
-        <Icon name="search" />
-      </Button>
     </SCsearchContainer>
   );
 };

--- a/client/components/molecules/SearchInput.tsx
+++ b/client/components/molecules/SearchInput.tsx
@@ -2,19 +2,26 @@ import React, { useContext } from 'react';
 import { Button, Input, Icon } from 'semantic-ui-react';
 import styled from 'styled-components';
 
-import { LoadingContext } from '../../Router';
+import { SearchKeywordContext } from '../../Router';
 
-const SearchInput = () => {
-  const { setLoading } = useContext(LoadingContext);
-  const onClickSearch = () => {
-    setLoading(true);
-    setTimeout(() => setLoading(false), 3000);
-  };
+type Props = {
+  count: number;
+  orderBy: string;
+  onClickSearchButton: (count: number, orderBy: string, keyword: string) => void;
+};
+
+const SearchInput = (props: Props) => {
+  const { count, orderBy, onClickSearchButton } = props;
+  const { keyword, setKeyword } = useContext(SearchKeywordContext);
 
   return (
     <SCsearchContainer>
-      <SCsearchInput placeholder="投稿を検索する" />
-      <Button icon color="teal" onClick={onClickSearch}>
+      <SCsearchInput
+        placeholder="投稿を検索する"
+        onChange={(_e: React.ChangeEvent<HTMLInputElement>, data: { value: string }) => setKeyword(data.value)}
+        defaultValue={keyword}
+      />
+      <Button icon color="teal" onClick={() => onClickSearchButton(count, orderBy, keyword)}>
         <Icon name="search" />
       </Button>
     </SCsearchContainer>

--- a/client/components/molecules/SearchInput.tsx
+++ b/client/components/molecules/SearchInput.tsx
@@ -1,20 +1,25 @@
-import React from 'react';
-import { Input } from 'semantic-ui-react';
+import React, { useState } from 'react';
+import { Button, Input, Icon } from 'semantic-ui-react';
 import styled from 'styled-components';
 
 type Props = {
-  onChangeSetKeyword: (content: string) => void;
+  onClickSetKeyword: (content: string) => void;
 };
 
 const SearchInput = (props: Props) => {
-  const { onChangeSetKeyword } = props;
+  const { onClickSetKeyword } = props;
+
+  const [keyword, setKeyword] = useState('');
 
   return (
     <SCsearchContainer>
       <SCsearchInput
         placeholder="投稿を検索する"
-        onChange={(_e: React.ChangeEvent<HTMLInputElement>, data: { value: string }) => onChangeSetKeyword(data.value)}
+        onChange={(_e: React.ChangeEvent<HTMLInputElement>, data: { value: string }) => setKeyword(data.value)}
       />
+      <Button icon color="teal" onClick={() => onClickSetKeyword(keyword)}>
+        <Icon name="search" />
+      </Button>
     </SCsearchContainer>
   );
 };

--- a/client/components/pages/Home.tsx
+++ b/client/components/pages/Home.tsx
@@ -18,7 +18,7 @@ const Home = () => {
       menuItem: '　　　人気順　　　',
       render: () => (
         <>
-          <SearchInput onChangeSetKeyword={setKeyword} />
+          <SearchInput onClickSetKeyword={setKeyword} />
           <Tab.Pane key="tabPopular" attached={false}>
             <TabPopular count={count} keyword={keyword} />
           </Tab.Pane>
@@ -29,7 +29,7 @@ const Home = () => {
       menuItem: '　　　新着順　　　',
       render: () => (
         <>
-          <SearchInput onChangeSetKeyword={setKeyword} />
+          <SearchInput onClickSetKeyword={setKeyword} />
           <Tab.Pane key="tabNew" attached={false}>
             <TabNew count={count} keyword={keyword} />
           </Tab.Pane>

--- a/client/components/pages/Home.tsx
+++ b/client/components/pages/Home.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { Button, Container, Segment, Tab, Icon } from 'semantic-ui-react';
 import styled from 'styled-components';
 import { useHistory } from 'react-router-dom';
@@ -6,33 +6,52 @@ import { useHistory } from 'react-router-dom';
 import SearchInput from '../molecules/SearchInput';
 import TabPopular from '../templates/TabPopular';
 import TabNew from '../templates/TabNew';
+import { LoadingContext } from '../../Router';
+import PostService from '../../repository/post';
 
 const Home = () => {
   const history = useHistory();
+  const { setLoading } = useContext(LoadingContext);
 
   const [count, setCount] = useState(15);
+  const [data, setData] = useState();
 
   const panes = [
     {
       menuItem: '　　　人気順　　　',
       render: () => (
-        <Tab.Pane key="tabPopular" attached={false}>
-          <TabPopular count={count} />
-        </Tab.Pane>
+        <>
+          <SearchInput count={count} orderBy="new" onClickSearchButton={onClickSearchButton} />
+          <Tab.Pane key="tabPopular" attached={false}>
+            <TabPopular count={count} data={data} getSearchData={onClickSearchButton} />
+          </Tab.Pane>
+        </>
       ),
     },
     {
       menuItem: '　　　新着順　　　',
       render: () => (
-        <Tab.Pane key="tabNew" attached={false}>
-          <TabNew count={count} />
-        </Tab.Pane>
+        <>
+          <SearchInput count={count} orderBy="new" onClickSearchButton={onClickSearchButton} />
+          <Tab.Pane key="tabNew" attached={false}>
+            <TabNew count={count} data={data} getSearchData={onClickSearchButton} />
+          </Tab.Pane>
+        </>
       ),
     },
   ];
 
   const onClickToPost = () => history.push('/post');
   const onClickCountButton = (num: number) => setCount(num);
+  const onClickSearchButton = (count: number, orderBy: string, keyword: string) => {
+    const searchPostFunc = async () => {
+      setLoading(true);
+      const res = await PostService.getPosts(count, orderBy, keyword);
+      setData(res.data.posts);
+      setLoading(false);
+    };
+    searchPostFunc();
+  };
 
   return (
     <>
@@ -45,7 +64,6 @@ const Home = () => {
           <Button.Content hidden>(ｏﾟДﾟ)＝◯)`3゜)∵</Button.Content>
         </Button>
         <Segment raised textAlign="center">
-          <SearchInput />
           <SCmenuContainer>
             <Tab menu={{ pointing: true, secondary: true, color: 'teal' }} panes={panes} />
           </SCmenuContainer>

--- a/client/components/pages/Home.tsx
+++ b/client/components/pages/Home.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import React, { useState } from 'react';
 import { Button, Container, Segment, Tab, Icon } from 'semantic-ui-react';
 import styled from 'styled-components';
 import { useHistory } from 'react-router-dom';
@@ -6,24 +6,21 @@ import { useHistory } from 'react-router-dom';
 import SearchInput from '../molecules/SearchInput';
 import TabPopular from '../templates/TabPopular';
 import TabNew from '../templates/TabNew';
-import { LoadingContext } from '../../Router';
-import PostService from '../../repository/post';
 
 const Home = () => {
   const history = useHistory();
-  const { setLoading } = useContext(LoadingContext);
 
   const [count, setCount] = useState(15);
-  const [data, setData] = useState();
+  const [keyword, setKeyword] = useState('');
 
   const panes = [
     {
       menuItem: '　　　人気順　　　',
       render: () => (
         <>
-          <SearchInput count={count} orderBy="new" onClickSearchButton={onClickSearchButton} />
+          <SearchInput onChangeSetKeyword={setKeyword} />
           <Tab.Pane key="tabPopular" attached={false}>
-            <TabPopular count={count} data={data} getSearchData={onClickSearchButton} />
+            <TabPopular count={count} keyword={keyword} />
           </Tab.Pane>
         </>
       ),
@@ -32,9 +29,9 @@ const Home = () => {
       menuItem: '　　　新着順　　　',
       render: () => (
         <>
-          <SearchInput count={count} orderBy="new" onClickSearchButton={onClickSearchButton} />
+          <SearchInput onChangeSetKeyword={setKeyword} />
           <Tab.Pane key="tabNew" attached={false}>
-            <TabNew count={count} data={data} getSearchData={onClickSearchButton} />
+            <TabNew count={count} keyword={keyword} />
           </Tab.Pane>
         </>
       ),
@@ -43,15 +40,6 @@ const Home = () => {
 
   const onClickToPost = () => history.push('/post');
   const onClickCountButton = (num: number) => setCount(num);
-  const onClickSearchButton = (count: number, orderBy: string, keyword: string) => {
-    const searchPostFunc = async () => {
-      setLoading(true);
-      const res = await PostService.getPosts(count, orderBy, keyword);
-      setData(res.data.posts);
-      setLoading(false);
-    };
-    searchPostFunc();
-  };
 
   return (
     <>

--- a/client/components/templates/TabNew.tsx
+++ b/client/components/templates/TabNew.tsx
@@ -1,36 +1,29 @@
-import React, { useEffect, useState, useContext } from 'react';
+import React, { useEffect, useContext } from 'react';
 import { List, Icon, Dimmer, Loader } from 'semantic-ui-react';
 import styled from 'styled-components';
 import { useHistory } from 'react-router-dom';
 
 import { Post } from '../../types/post';
-import PostService from '../../repository/post';
-import { LoadingContext } from '../../Router';
+import { SearchKeywordContext } from '../../Router';
 
 type Props = {
   count: number;
+  data: Post[];
+  getSearchData: (count: number, orderBy: string, keyword: string) => void;
 };
 
 const TabNew = (props: Props) => {
-  const { count } = props;
+  const { count, data, getSearchData } = props;
+  const { keyword } = useContext(SearchKeywordContext);
   const history = useHistory();
-  const { setLoading } = useContext(LoadingContext);
-
-  const [data, setData] = useState();
-
-  useEffect(() => {
-    const postFunc = async () => {
-      setLoading(true);
-      const res = await PostService.getPosts(count, 'new');
-      setData(res.data.posts);
-      setLoading(false);
-    };
-    postFunc();
-  }, [count, setLoading]);
 
   const onClickToDetail = (id: number) => {
     history.push(`/detail/${id}`);
   };
+
+  useEffect(() => {
+    getSearchData(count, 'new', keyword);
+  }, [count]);
 
   return (
     <SCcontainer>

--- a/client/components/templates/TabNew.tsx
+++ b/client/components/templates/TabNew.tsx
@@ -1,29 +1,33 @@
-import React, { useEffect, useContext } from 'react';
+import React, { useEffect, useState } from 'react';
 import { List, Icon, Dimmer, Loader } from 'semantic-ui-react';
 import styled from 'styled-components';
 import { useHistory } from 'react-router-dom';
 
 import { Post } from '../../types/post';
-import { SearchKeywordContext } from '../../Router';
+import PostService from '../../repository/post';
 
 type Props = {
   count: number;
-  data: Post[];
-  getSearchData: (count: number, orderBy: string, keyword: string) => void;
+  keyword: string;
 };
 
 const TabNew = (props: Props) => {
-  const { count, data, getSearchData } = props;
-  const { keyword } = useContext(SearchKeywordContext);
+  const { count, keyword } = props;
   const history = useHistory();
+
+  const [data, setData] = useState();
+
+  useEffect(() => {
+    const postFunc = async () => {
+      const res = await PostService.getPosts(count, 'new', keyword);
+      setData(res.data.posts);
+    };
+    postFunc();
+  }, [count, keyword]);
 
   const onClickToDetail = (id: number) => {
     history.push(`/detail/${id}`);
   };
-
-  useEffect(() => {
-    getSearchData(count, 'new', keyword);
-  }, [count]);
 
   return (
     <SCcontainer>

--- a/client/components/templates/TabPopular.tsx
+++ b/client/components/templates/TabPopular.tsx
@@ -1,29 +1,33 @@
-import React, { useEffect, useContext } from 'react';
+import React, { useEffect, useState } from 'react';
 import { List, Icon, Dimmer, Loader } from 'semantic-ui-react';
 import styled from 'styled-components';
 import { useHistory } from 'react-router-dom';
 
 import { Post } from '../../types/post';
-import { SearchKeywordContext } from '../../Router';
+import PostService from '../../repository/post';
 
 type Props = {
   count: number;
-  data: Post[];
-  getSearchData: (count: number, orderBy: string, keyword: string) => void;
+  keyword: string;
 };
 
 const TabPopular = (props: Props) => {
-  const { count, data, getSearchData } = props;
+  const { count, keyword } = props;
   const history = useHistory();
-  const { keyword } = useContext(SearchKeywordContext);
+
+  const [data, setData] = useState();
+
+  useEffect(() => {
+    const postFunc = async () => {
+      const res = await PostService.getPosts(count, '', keyword);
+      setData(res.data.posts);
+    };
+    postFunc();
+  }, [count, keyword]);
 
   const onClickToDetail = (id: number) => {
     history.push(`/detail/${id}`);
   };
-
-  useEffect(() => {
-    getSearchData(count, '', keyword);
-  }, [count]);
 
   return (
     <SCcontainer>

--- a/client/components/templates/TabPopular.tsx
+++ b/client/components/templates/TabPopular.tsx
@@ -1,36 +1,29 @@
-import React, { useEffect, useState, useContext } from 'react';
+import React, { useEffect, useContext } from 'react';
 import { List, Icon, Dimmer, Loader } from 'semantic-ui-react';
 import styled from 'styled-components';
 import { useHistory } from 'react-router-dom';
 
 import { Post } from '../../types/post';
-import PostService from '../../repository/post';
-import { LoadingContext } from '../../Router';
+import { SearchKeywordContext } from '../../Router';
 
 type Props = {
   count: number;
+  data: Post[];
+  getSearchData: (count: number, orderBy: string, keyword: string) => void;
 };
 
 const TabPopular = (props: Props) => {
-  const { count } = props;
+  const { count, data, getSearchData } = props;
   const history = useHistory();
-  const { setLoading } = useContext(LoadingContext);
-
-  const [data, setData] = useState();
-
-  useEffect(() => {
-    const postFunc = async () => {
-      setLoading(true);
-      const res = await PostService.getPosts(count, '');
-      setData(res.data.posts);
-      setLoading(false);
-    };
-    postFunc();
-  }, [count, setLoading]);
+  const { keyword } = useContext(SearchKeywordContext);
 
   const onClickToDetail = (id: number) => {
     history.push(`/detail/${id}`);
   };
+
+  useEffect(() => {
+    getSearchData(count, '', keyword);
+  }, [count]);
 
   return (
     <SCcontainer>

--- a/client/repository/post.ts
+++ b/client/repository/post.ts
@@ -5,13 +5,16 @@ import { internalServerError, genericError } from './share';
 import { SuccessResult, ErrorResult } from '../types/api';
 
 export default {
-  async getPosts(count: number, orderBy: string): Promise<SuccessResult<any> | ErrorResult> {
-    const response = await axiosInstance.get(`/post?count=${count}&order_by=${orderBy}`).catch((e: AxiosError) => {
-      if (e.isAxiosError) {
-        return internalServerError;
-      }
-    });
+  async getPosts(count: number, orderBy: string, keyword: string): Promise<SuccessResult<any> | ErrorResult> {
+    const response = await axiosInstance
+      .get(`/post?count=${count}&order_by=${orderBy}&keyword=${keyword}`)
+      .catch((e: AxiosError) => {
+        if (e.isAxiosError) {
+          return internalServerError;
+        }
+      });
     if (response?.status === 200) {
+      console.log(response.data);
       return {
         error: false,
         data: response.data,

--- a/client/repository/post.ts
+++ b/client/repository/post.ts
@@ -14,7 +14,6 @@ export default {
         }
       });
     if (response?.status === 200) {
-      console.log(response.data);
       return {
         error: false,
         data: response.data,

--- a/client/types/context.ts
+++ b/client/types/context.ts
@@ -4,3 +4,8 @@ export interface Loading {
   loading: boolean;
   setLoading: Dispatch<SetStateAction<boolean>>;
 }
+
+export interface SearchKeyword {
+  keyword: string;
+  setKeyword: Dispatch<SetStateAction<string>>;
+}


### PR DESCRIPTION
## 対応内容
- 以前は並び替えのタブの上に検索コンポーネントを持ってきていたのですが、検索結果と一緒に並び替えも適用させたかったので、並び替えタブの内部に移動させました。
- 検索APIの繋ぎ込みで実際に検索フォームに入力、ボタンを押すと検索結果が表示されるように実装しました。

## 特に見て欲しいところ
- 検索フォームに入力、ボタンを押すと検索結果が表示されるところ
- 検索キーワードを共有するためにuseContextを使ったのですが、そのせいでネストさせてしてしまってます... 他の方法があれば修正します！

## ちょっと詰まったところ(教えていただけたらありがたいです...!🙇‍♂️)
<img width="978" alt="スクリーンショット 2020-04-19 18 57 59" src="https://user-images.githubusercontent.com/42334697/79686358-b5722880-827a-11ea-8f40-90dfa79ec2f5.png">

ここの警告を消したかったのですが、どうも消えなくて...
- `keyword`, `getSearch`を追加すると無限ループになる
- `[]`の空配列だと警告が出てしまう
- `[]`を消すと無限ループになる

ご確認よろしくお願いします！